### PR TITLE
Add Coverage Artifact Upload to CI workflow

### DIFF
--- a/ci_lab/ci.yml
+++ b/ci_lab/ci.yml
@@ -1,0 +1,50 @@
+name: CI Workflow  # Name of the workflow
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest  # Use the latest Ubuntu runner
+    defaults:
+      run:
+        working-directory: ci_lab  # Set the default working directory for all steps
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      - name: Set Up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"  # Ensure consistency in Python version
+
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run Tests with Pytest
+        run: pytest --cov=src --cov-report=term-missing
+
+      - name: Install Flake8
+        run: pip install flake8
+
+      - name: Run Flake8 Linting
+        run: flake8 src --count --select=E9,F63,F7,F82 --show-source --statistics
+
+      # author: Eshan Ahmad
+      - name: Run Tests with Pytest and coverage artifact
+        run: |
+          --cov=src --cov-report=term-missing
+          --cov-report=html \
+          --cov-report=annotate:artifact.txt
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverageReport
+          path: |
+            ci_lab/htmlcov
+            ci_lab/artifact.txt
+


### PR DESCRIPTION
YAML change:

added:
      # author: Eshan Ahmad
      - name: Run Tests with Pytest and coverage artifact
        run: |
          --cov=src --cov-report=term-missing
          --cov-report=html \
          --cov-report=annotate:artifact.txt

      - name: Upload coverage artifact
        uses: actions/upload-artifact@v3
        with:
          name: coverageReport
          path: |
            ci_lab/htmlcov
            ci_lab/artifact.txt

explanation of change:
This will generate an html/text coverage report during the pytest run then upload the report as an artifact to github actions.